### PR TITLE
Add overload to BindAsync to enable Task<Result> inputs

### DIFF
--- a/DiscriminatedOnions.Tests/ReadMeExamples.cs
+++ b/DiscriminatedOnions.Tests/ReadMeExamples.cs
@@ -106,9 +106,8 @@ public static class ReadMeExamples
     public static async Task Result_BindAsync_Ok()
     {
         Result<string, int> ok = Result.Ok<string, int>("result value");
-        Result<string, int> asyncBoundOk = await ok
-            .BindAsync(v => Task.FromResult(Result.Ok<string, int>("beautiful " + v)))
-            .Pipe(o => o.BindAsync(v => Task.FromResult(Result.Ok<string, int>("very " + v))));
+        var bindAsyncResult = await ok.BindAsync(v => Task.FromResult(Result.Ok<string, int>("beautiful " + v)));
+        Result<string, int> asyncBoundOk = await bindAsyncResult.Pipe(o => o.BindAsync(v => Task.FromResult(Result.Ok<string, int>("very " + v))));
         asyncBoundOk.Should().Be(Result.Ok<string, int>("very beautiful result value"));
     }
 

--- a/DiscriminatedOnions.Tests/ResultTest.cs
+++ b/DiscriminatedOnions.Tests/ResultTest.cs
@@ -121,6 +121,24 @@ public static class ResultTest
         .Should().Be((42, DummyResultValue));
 
     [Test]
+    public static async Task BindAsync_AsyncInput_Ok() =>
+        (await Task.FromResult(Result.Ok<string, int>("resultValue"))
+            .BindAsync(v => Task.FromResult(Result.Ok<string, int>(v + "Altered")))
+            .Pipe(r => r.Match(
+                onError: e => (e, DummyResultValue),
+                onOk: v => (DummyErrorValue, v))))
+        .Should().Be((DummyErrorValue, "resultValueAltered"));
+
+    [Test]
+    public static async Task BindAsync_AsyncInput_Error() =>
+        (await Task.FromResult(Result.Error<string, int>(42))
+            .BindAsync(v => Task.FromResult(Result.Ok<string, int>(v + "Altered")))
+            .Pipe(r => r.Match(
+                onError: e => (e, DummyResultValue),
+                onOk: v => (DummyErrorValue, v))))
+        .Should().Be((42, DummyResultValue));
+
+    [Test]
     public static void Map_Ok() =>
         Result.Ok<string, int>("resultValue")
             .Map(v => v + "Altered")

--- a/DiscriminatedOnions/Result.cs
+++ b/DiscriminatedOnions/Result.cs
@@ -73,6 +73,12 @@ public static class Result
     public static Result<U, TError> Bind<T, TError, U>(this Result<T, TError> result, Func<T, Result<U, TError>> binder) =>
         result.Match(Error<U, TError>, binder);
 
+    public static async Task<Result<U, TError>> BindAsync<T, TError, U>(this Task<Result<T, TError>> result, Func<T, Task<Result<U, TError>>> binder)
+    {
+        var actualResult = await result;
+        return await actualResult.Match(e => Task.FromResult(Error<U, TError>(e)), binder);
+    }
+
     public static Task<Result<U, TError>> BindAsync<T, TError, U>(this Result<T, TError> result, Func<T, Task<Result<U, TError>>> binder) =>
         result.Match(e => Task.FromResult(Error<U, TError>(e)), binder);
 


### PR DESCRIPTION
Hi @salvois, 
Now that I was able to see all the extensions you implemented, I think there is another one which can be helpful to avoid external awaiting and parentheses madness.

Please take a look :)